### PR TITLE
feat(api): Create centralized axios instance with auth interceptor

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,29 @@
+import axios from 'axios';
+
+const apiClient = axios.create({
+    baseURL: 'https://api-museu-magma.onrender.com/api/v1',
+    headers: {
+        'Content-Type': 'application/json',
+    },
+});
+
+
+// ===================================================================
+// Request Interceptor - This interceptor runs BEFORE each request is sent.
+// ===================================================================
+apiClient.interceptors.request.use(
+    (config) => {
+        const acessToken = localStorage.getItem('accessToken'); 
+
+        if (acessToken) {
+            config.headers.Authorization = `Bearer ${acessToken}`;
+        }
+
+        return config;
+    },
+    (error) => {
+        return Promise.reject(error);
+    }
+);
+
+export default apiClient;


### PR DESCRIPTION
This module sets up a pre-configured Axios client with the base API URL and an interceptor that automatically attaches the JWT Bearer token to outgoing requests.