### PR TITLE
fix(routing): Allow sellers to access read-only product page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,7 +45,11 @@ function App() {
                         <Route
                             element={
                                 <RoleProtectedRoute
-                                    allowedRoles={['ADMIN', 'STOCKCLERK']}
+                                    allowedRoles={[
+                                        'ADMIN',
+                                        'STOCKCLERK',
+                                        'SELLER',
+                                    ]}
                                 />
                             }>
                             <Route

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -16,6 +16,7 @@ const Sidebar = () => {
         SELLER: [
             { path: '/dashboard', label: 'Dashboard' },
             { path: '/sales', label: 'Minhas Vendas' },
+            { path: '/products', label: 'Visualizar Produtos' },
         ],
         STOCKCLERK: [
             { path: '/dashboard', label: 'Dashboard' },


### PR DESCRIPTION
Updates the RoleProtectedRoute for the /products route to include the 'SELLER' role, granting them the required read-only access as defined by the API permissions.