### PR TITLE
feat(stock): Implement stock movement history page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import NewSalePage from './pages/SalesPage/NewSalePage/NewSalePage';
 import UsersPage from './pages/UsersPage/UsersPage';
 import UnauthorizedPage from './pages/UnauthorizedPage/UnauthorizedPage';
 import CustomersPage from './pages/CustomersPage/CustomersPage';
+import StockMovementsPage from './pages/StockMovementsPage/StockMovementsPage';
 
 function App() {
     return (
@@ -43,10 +44,6 @@ function App() {
                                 path="/dashboard"
                                 element={<DashboardPage />}
                             />
-                            <Route
-                                path="/products"
-                                element={<ProductsPage />}
-                            />
                         </Route>
                         <Route
                             element={
@@ -69,6 +66,21 @@ function App() {
                                 <RoleProtectedRoute allowedRoles={['ADMIN']} />
                             }>
                             <Route path="/users" element={<UsersPage />} />
+                        </Route>
+                        <Route
+                            element={
+                                <RoleProtectedRoute
+                                    allowedRoles={['ADMIN', 'STOCKCLERK']}
+                                />
+                            }>
+                            <Route
+                                path="/products"
+                                element={<ProductsPage />}
+                            />
+                            <Route
+                                path="/stock-movements"
+                                element={<StockMovementsPage />}
+                            />
                         </Route>
                     </Route>
 

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -12,6 +12,7 @@ const Sidebar = () => {
             { path: '/customers', label: 'Clientes' },
             { path: '/sales', label: 'Vendas' },
             { path: '/products', label: 'Produtos' },
+            { path: '/stock-movements', label: 'Histórico de Estoque' },
             { path: '/users', label: 'Usuários' },
         ],
         SELLER: [
@@ -23,6 +24,7 @@ const Sidebar = () => {
         STOCKCLERK: [
             { path: '/dashboard', label: 'Dashboard' },
             { path: '/products', label: 'Produtos' },
+            { path: '/stock-movements', label: 'Histórico de Estoque' },
         ],
     };
 

--- a/src/pages/StockMovementsPage/StockMovementsPage.css
+++ b/src/pages/StockMovementsPage/StockMovementsPage.css
@@ -1,0 +1,41 @@
+.stock-movements-page {
+    animation: fadeIn 0.5s ease-in-out;
+}
+
+.search-bar {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.filters-container {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.filters-container label {
+    font-weight: 500;
+}
+
+.filters-container select {
+    min-width: 250px;
+    background-color: var(--color-background);
+}
+
+.type-badge {
+    font-weight: 700;
+}
+
+.type-entry {
+    color: var(--color-success);
+}
+
+.type-sale {
+    color: var(--color-error);
+}
+
+.type-adjust {
+    color: var(--color-warning);
+}

--- a/src/pages/StockMovementsPage/StockMovementsPage.jsx
+++ b/src/pages/StockMovementsPage/StockMovementsPage.jsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import Spinner from '../../components/common/Spinner/Spinner';
+import './StockMovementsPage.css';
+import useApi from '../../hooks/useApi';
+
+const StockMovementsPage = () => {
+    const [searchTerm, setSearchTerm] = useState('');
+    const [activeSearch, setActiveSearch] = useState('');
+    const endpoint = activeSearch
+        ? `/stock-movements/?search=${activeSearch}`
+        : '/stock-movements/';
+
+    const { data: movements, loading, error } = useApi(endpoint);
+
+    const handleSearchSubmit = (e) => {
+        e.preventDefault();
+        setActiveSearch(searchTerm);
+    };
+
+    const getMovementTypeClass = (type) => {
+        switch (type) {
+            case 'ENTRY':
+                return 'type-entry';
+            case 'SALE':
+                return 'type-sale';
+            case 'ADJUST':
+                return 'type-adjust';
+            default:
+                return '';
+        }
+    };
+
+    if (loading) return <Spinner />;
+    if (error) return <div className="error-message">{error}</div>;
+
+    return (
+        <div className="stock-movements-page">
+            <header className="page-header">
+                <h1>Histórico de Movimentações de Estoque</h1>
+            </header>
+
+            <form className="search-bar" onSubmit={handleSearchSubmit}>
+                <input
+                    type="text"
+                    placeholder="Filtrar por nome do produto..."
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                />
+                <button type="submit">Buscar</button>
+            </form>
+
+            <div className="list-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Data</th>
+                            <th>ID produto</th>
+                            <th>Produto</th>
+                            <th>Tipo</th>
+                            <th>Quantidade</th>
+                            <th>Custo Unit.</th>
+                            <th>Usuário</th>
+                            <th>Observações</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {movements.map((mov) => (
+                            <tr key={mov.id}>
+                                <td>
+                                    {new Date(mov.timestamp).toLocaleString(
+                                        'pt-BR',
+                                    )}
+                                </td>
+                                <td>{mov.product}</td>
+                                <td>{mov.product_name}</td>
+                                <td>
+                                    <span
+                                        className={`type-badge ${getMovementTypeClass(
+                                            mov.type,
+                                        )}`}>
+                                        {mov.type_display}
+                                    </span>
+                                </td>
+                                <td>{mov.quantity}</td>
+                                <td>R$ {mov.cost_price}</td>
+                                <td>{mov.user_name}</td>
+                                <td>{mov.notes}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+};
+
+export default StockMovementsPage;


### PR DESCRIPTION
Creates a new read-only page at /stock-movements to display the history of all stock movements. The page consumes the /api/v1/stock-movements/ endpoint and includes a search bar to filter movements by product name, replicating functionality from the original monolithic system.