### PR TITLE
feat(reports): Create profitability report page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.12.0",
+        "chart.js": "^4.5.0",
         "jwt-decode": "^4.0.0",
         "prop-types": "^15.8.1",
         "react": "^19.1.1",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.2"
       },
@@ -633,6 +635,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.32",
@@ -1296,6 +1304,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/color-convert": {
@@ -2318,6 +2338,16 @@
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   },
   "dependencies": {
     "axios": "^1.12.0",
+    "chart.js": "^4.5.0",
     "jwt-decode": "^4.0.0",
     "prop-types": "^15.8.1",
     "react": "^19.1.1",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.2"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import UsersPage from './pages/UsersPage/UsersPage';
 import UnauthorizedPage from './pages/UnauthorizedPage/UnauthorizedPage';
 import CustomersPage from './pages/CustomersPage/CustomersPage';
 import StockMovementsPage from './pages/StockMovementsPage/StockMovementsPage';
+import ProfitabilityReportPage from './pages/Reports/ProfitabilityReportPage';
 
 function App() {
     return (
@@ -66,6 +67,10 @@ function App() {
                                 <RoleProtectedRoute allowedRoles={['ADMIN']} />
                             }>
                             <Route path="/users" element={<UsersPage />} />
+                            <Route
+                                path="/reports/profitability"
+                                element={<ProfitabilityReportPage />}
+                            />
                         </Route>
                         <Route
                             element={

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -14,6 +14,7 @@ const Sidebar = () => {
             { path: '/products', label: 'Produtos' },
             { path: '/stock-movements', label: 'Histórico de Estoque' },
             { path: '/users', label: 'Usuários' },
+            { path: '/reports/profitability', label: 'Relatório de Lucro' },
         ],
         SELLER: [
             { path: '/dashboard', label: 'Dashboard' },

--- a/src/pages/Reports/ProfitabilityReportPage.jsx
+++ b/src/pages/Reports/ProfitabilityReportPage.jsx
@@ -1,0 +1,134 @@
+import React, { useMemo } from 'react';
+import { Bar, Line } from 'react-chartjs-2';
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    BarElement,
+    LineElement,
+    PointElement,
+    Title,
+    Tooltip,
+    Legend,
+} from 'chart.js';
+import useApi from '../../hooks/useApi';
+import Spinner from '../../components/common/Spinner/Spinner';
+import './Reports.css';
+
+ChartJS.register(
+    CategoryScale,
+    LinearScale,
+    BarElement,
+    LineElement,
+    PointElement,
+    Title,
+    Tooltip,
+    Legend,
+);
+
+const ProfitabilityReportPage = () => {
+    const {
+        data: sales,
+        loading: loadingSales,
+        error: errorSales,
+    } = useApi('/sales');
+    const {
+        data: products,
+        loading: loadingProducts,
+        error: errorProducts,
+    } = useApi('/products');
+
+    const chartData = useMemo(() => {
+        if (!sales || !products) return null;
+
+        const productCategoryMap = products.reduce((acc, product) => {
+            acc[product.id] = product.category_display;
+            return acc;
+        }, {});
+
+        const profitByCategory = sales.reduce((acc, sale) => {
+            const saleProfit =
+                parseFloat(sale.total_amount) - parseFloat(sale.total_cost);
+
+            for (const item of sale.items) {
+                const category = productCategoryMap[item.id];
+                if (category) {
+                    acc[category] = (acc[category] || 0) + saleProfit;
+                }
+            }
+
+            return acc;
+        }, {});
+
+        const profitByMonth = sales.reduce((acc, sale) => {
+            const month = new Date(sale.sale_date).toLocaleString('pt-BR', {
+                month: 'short',
+                year: '2-digit',
+            });
+            const saleProfit =
+                parseFloat(sale.total_amount) - parseFloat(sale.total_cost);
+
+            acc[month] = (acc[month] || 0) + saleProfit;
+            return acc;
+        }, {});
+
+        const sortedMonths = Object.keys(profitByMonth).sort(
+            (a, b) =>
+                new Date('01 ' + a.replace("'", '')) -
+                new Date('01 ' + b.replace("'", '')),
+        );
+
+        return {
+            byCategory: {
+                label: Object.keys(profitByCategory),
+                datasets: [
+                    {
+                        label: 'Lucro por Categoria (R$)',
+                        data: Object.values(profitByCategory),
+                        backgroundColor: 'rgba(229, 122, 68, 0.6)',
+                        borderColor: 'rgba(229, 122, 68, 1)',
+                        borderWidth: 1,
+                    },
+                ],
+            },
+            byMonth: {
+                labels: sortedMonths,
+                datasets: [
+                    {
+                        label: 'Lucro por Mês (R$)',
+                        data: sortedMonths.map((month) => profitByMonth[month]),
+                        fill: false,
+                        borderColor: 'rgba(244, 184, 96, 1)',
+                        tension: 0.1,
+                    },
+                ],
+            },
+        };
+    }, [sales, products]);
+
+    if (loadingSales || loadingProducts) return <Spinner />;
+    if (errorSales || errorProducts)
+        return (
+            <div className="error-message">{errorSales || errorProducts}</div>
+        );
+    
+    return (
+        <div className="report-page">
+            <header className="page-header">
+                <h1>Relatório de Lucratividade</h1>
+            </header>
+            <div className="report-grid">
+                <div className="chart-container">
+                    <h3>Lucro por Categoria</h3>
+                    {chartData && <Bar data={chartData.byCategory} />}
+                </div>
+                <div className="chart-container">
+                    <h3>Lucro ao Longo do Tempo</h3>
+                    {chartData && <Line data={chartData.byMonth} />}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ProfitabilityReportPage;

--- a/src/pages/Reports/Reports.css
+++ b/src/pages/Reports/Reports.css
@@ -1,0 +1,19 @@
+.report-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    gap: 2rem;
+}
+
+.chart-container {
+    background-color: var(--color-background-light);
+    padding: 1.5rem;
+    border-radius: 8px;
+    border: 1px solid var(--color-border);
+}
+
+.chart-container h3 {
+    text-align: center;
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    color: var(--color-text);
+}


### PR DESCRIPTION
Adds a new admin-only report page to visualize profitability. It fetches sales and products data, processes it, and displays charts for profit by category (Bar) and profit over time (Line) using Chart.js.